### PR TITLE
#1575 - Concurrent vPool creation

### DIFF
--- a/source/controllers/asd.py
+++ b/source/controllers/asd.py
@@ -66,7 +66,7 @@ class ASDController(object):
                         continue
                     service_name = ASDController.ASD_SERVICE_PREFIX.format(asd_id)
                     if ServiceManager.has_service(service_name, ASDController._local_client):
-                        if ServiceManager.get_service_status(service_name, ASDController._local_client)[0] is False:
+                        if ServiceManager.get_service_status(service_name, ASDController._local_client) != 'active':
                             asds[asd_id].update({'state': 'error',
                                                  'state_detail': 'service_failure'})
                         else:

--- a/source/controllers/update.py
+++ b/source/controllers/update.py
@@ -144,8 +144,7 @@ class SDMUpdateController(object):
         service_names = [service_name for service_name in ASDController.list_asd_services()]
         service_names.extend([service_name for service_name in MaintenanceController.get_services()])
         for service_name in service_names:
-            status, _ = ServiceManager.get_service_status(service_name, SDMUpdateController._local_client)
-            if status is False:
+            if ServiceManager.get_service_status(service_name, SDMUpdateController._local_client) != 'active':
                 SDMUpdateController._logger.warning('Found stopped service {0}. Will not start it.'.format(service_name))
                 continue
 

--- a/source/tools/install/post-update.py
+++ b/source/tools/install/post-update.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
         version = Configuration.get(key) if Configuration.exists(key) else 0
 
         asd_manager_service_name = 'asd-manager'
-        if ServiceManager.has_service(asd_manager_service_name, client) and ServiceManager.get_service_status(asd_manager_service_name, client)[0] is True:
+        if ServiceManager.has_service(asd_manager_service_name, client) and ServiceManager.get_service_status(asd_manager_service_name, client) == 'active':
             _logger.info('Stopping asd-manager service')
             ServiceManager.stop_service(asd_manager_service_name, client)
 
@@ -125,7 +125,7 @@ if __name__ == '__main__':
                 _logger.exception('Error while executing post-update code on node {0}'.format(NODE_ID))
         Configuration.set(key, CURRENT_VERSION)
 
-        if ServiceManager.has_service(asd_manager_service_name, client) and ServiceManager.get_service_status(asd_manager_service_name, client)[0] is False:
+        if ServiceManager.has_service(asd_manager_service_name, client) and ServiceManager.get_service_status(asd_manager_service_name, client) != 'active':
             _logger.info('Starting asd-manager service')
             ServiceManager.start_service(asd_manager_service_name, client)
 

--- a/source/tools/services/upstart.py
+++ b/source/tools/services/upstart.py
@@ -124,8 +124,7 @@ class Upstart(object):
         if startup_dependency == '':
             startup_dependency = None
         else:
-            startup_dependency = '.'.join(
-                startup_dependency.split('.')[:-1])  # Remove .service from startup dependency
+            startup_dependency = '.'.join(startup_dependency.split('.')[:-1])  # Remove .service from startup dependency
         output = Upstart.add_service(name=name,
                                      client=client,
                                      params=service_params,
@@ -143,8 +142,8 @@ class Upstart(object):
         :type name: str
         :param client: Client on which to retrieve the status
         :type client: source.tools.localclient.LocalClient
-        :return: The status of the service and the output of the command
-        :rtype: tuple
+        :return: The status of the service
+        :rtype: str
         """
         try:
             name = Upstart._get_name(name, client)
@@ -152,13 +151,15 @@ class Upstart(object):
             # Special cases (especially old SysV ones)
             if 'rabbitmq' in name:
                 status = re.search('\{pid,\d+?\}', output) is not None
-                return status, output
+                if status is True:
+                    return 'active'
+                return 'inactive'
             # Normal cases - or if the above code didn't yield an outcome
             if 'start/running' in output or 'is running' in output:
-                return True, output
+                return 'active'
             if 'stop' in output or 'not running' in output:
-                return False, output
-            return False, output
+                return 'inactive'
+            return output
         except CalledProcessError as ex:
             Upstart._logger.exception('Get {0}.service status failed: {1}'.format(name, ex))
             raise Exception('Retrieving status for service "{0}" failed'.format(name))
@@ -185,86 +186,82 @@ class Upstart(object):
             Upstart.unregister_service(service_name=name, node_name='')
 
     @staticmethod
-    def start_service(name, client):
+    def start_service(name, client, timeout=5):
         """
         Start a service
         :param name: Name of the service to start
         :type name: str
         :param client: Client on which to start the service
         :type client: source.tools.localclient.LocalClient
-        :return: The output of the start command
-        :rtype: str
+        :param timeout: Timeout within to verify the service status (in seconds)
+        :type timeout: int
+        :return: None
+        :rtype: NoneType
         """
-        status, output = Upstart.get_service_status(name, client)
-        if status is True:
-            return output
+        if Upstart.get_service_status(name, client) == 'active':
+            return
+
+        name = Upstart._get_name(name, client)
+        timeout = timeout if timeout > 0 else 5
         try:
-            name = Upstart._get_name(name, client)
             client.run(['service', name, 'start'])
+            counter = 0
+            while counter < timeout * 4:
+                if Upstart.get_service_status(name=name, client=client) == 'active':
+                    return
+                time.sleep(0.25)
+                counter += 1
         except CalledProcessError as cpe:
-            output = cpe.output
-            Upstart._logger.exception('Start {0} failed, {1}'.format(name, output))
-            raise RuntimeError('Start {0} failed. {1}'.format(name, output))
-        tries = 10
-        while tries > 0:
-            status, output = Upstart.get_service_status(name, client)
-            if status is True:
-                return output
-            tries -= 1
-            time.sleep(10 - tries)
-        status, output = Upstart.get_service_status(name, client)
-        if status is True:
-            return output
-        Upstart._logger.error('Start {0} failed. {1}'.format(name, output))
-        raise RuntimeError('Start {0} failed. {1}'.format(name, output))
+            Upstart._logger.exception('Start {0} failed, {1}'.format(name, cpe.output))
+            raise
+        raise RuntimeError('Did not manage to start service {0} on node with IP {1}'.format(name, client.ip))
 
     @staticmethod
-    def stop_service(name, client):
+    def stop_service(name, client, timeout=5):
         """
         Stop a service
         :param name: Name of the service to stop
         :type name: str
         :param client: Client on which to stop the service
         :type client: source.tools.localclient.LocalClient
-        :return: The output of the stop command
-        :rtype: str
+        :param timeout: Timeout within to verify the service status (in seconds)
+        :type timeout: int
+        :return: None
+        :rtype: NoneType
         """
-        status, output = Upstart.get_service_status(name, client)
-        if status is False:
-            return output
+        if Upstart.get_service_status(name, client) == 'inactive':
+            return
+
+        name = Upstart._get_name(name, client)
+        timeout = timeout if timeout > 0 else 5
         try:
-            name = Upstart._get_name(name, client)
             client.run(['service', name, 'stop'])
+            counter = 0
+            while counter < timeout * 4:
+                if Upstart.get_service_status(name=name, client=client) == 'inactive':
+                    return
+                time.sleep(0.25)
+                counter += 1
         except CalledProcessError as cpe:
-            output = cpe.output
-            Upstart._logger.exception('Stop {0} failed, {1}'.format(name, output))
-            raise RuntimeError('Stop {0} failed, {1}'.format(name, output))
-        tries = 10
-        while tries > 0:
-            status, output = Upstart.get_service_status(name, client)
-            if status is False:
-                return output
-            tries -= 1
-            time.sleep(10 - tries)
-        status, output = Upstart.get_service_status(name, client)
-        if status is False:
-            return output
-        Upstart._logger.error('Stop {0} failed. {1}'.format(name, output))
-        raise RuntimeError('Stop {0} failed. {1}'.format(name, output))
+            Upstart._logger.exception('Stop {0} failed, {1}'.format(name, cpe.output))
+            raise
+        raise RuntimeError('Did not manage to stop service {0} on node with IP {1}'.format(name, client.ip))
 
     @staticmethod
-    def restart_service(name, client):
+    def restart_service(name, client, timeout=5):
         """
         Restart a service
         :param name: Name of the service to restart
         :type name: str
         :param client: Client on which to restart the service
         :type client: source.tools.localclient.LocalClient
-        :return: The output of the restart command
-        :rtype: str
+        :param timeout: Timeout within to verify the service status (in seconds)
+        :type timeout: int
+        :return: None
+        :rtype: NoneType
         """
-        Upstart.stop_service(name, client)
-        return Upstart.start_service(name, client)
+        Upstart.stop_service(name, client, timeout)
+        Upstart.start_service(name, client, timeout)
 
     @staticmethod
     def has_service(name, client):
@@ -279,9 +276,9 @@ class Upstart(object):
         """
         try:
             Upstart._get_name(name, client, log=False)
-            return True
         except ValueError:
             return False
+        return True
 
     @staticmethod
     def get_service_pid(name, client):
@@ -295,7 +292,7 @@ class Upstart(object):
         :rtype: int
         """
         name = Upstart._get_name(name, client)
-        if Upstart.get_service_status(name, client)[0] is True:
+        if Upstart.get_service_status(name, client) == 'active':
             output = client.run(['service', name, 'status'])
             if output:
                 # Special cases (especially old SysV ones)
@@ -321,6 +318,7 @@ class Upstart(object):
         :param client: Client on which to send a signal to the service
         :type client: source.tools.localclient.LocalClient
         :return: None
+        :rtype: NoneType
         """
         name = Upstart._get_name(name, client)
         pid = Upstart.get_service_pid(name, client)
@@ -346,6 +344,7 @@ class Upstart(object):
         """
         Monitor the local ASD services
         :return: None
+        :rtype: NoneType
         """
         try:
             previous_output = None


### PR DESCRIPTION
Changes in ServiceManagement
Start service raises if service is not started properly
Stop service raises if service is not started properly
Get service status only returns the status as returned by systemctl, eg: 'active'