### PR TITLE
Unify config paths in managers

### DIFF
--- a/source/asdmanager.py
+++ b/source/asdmanager.py
@@ -33,7 +33,7 @@ from source.dal.lists.asdlist import ASDList
 from source.dal.lists.disklist import DiskList
 from source.dal.lists.settinglist import SettingList
 from source.dal.objects.setting import Setting
-from source.constants.asd import ASD_NODE_CONFIG_MAIN_LOCATION, CACC_LOCATION, CACC_SOURCE, CONFIG_STORE_LOCATION
+from source.constants.asd import ASD_NODE_CONFIG_MAIN_LOCATION, CACC_LOCATION, CONFIG_STORE_LOCATION
 from source.controllers.asd import ASDController
 from source.controllers.disk import DiskController
 from source.controllers.maintenance import MaintenanceController
@@ -136,12 +136,6 @@ def setup():
                        message='\n' + Interactive.boxed_message(['API port cannot be in the range of the ASD port + 100']))
         sys.exit(1)
 
-    # Write necessary files
-    if not local_client.file_exists(CACC_LOCATION) and local_client.file_exists(CACC_SOURCE):  # Try to copy automatically
-        try:
-            local_client.file_upload(CACC_LOCATION, CACC_SOURCE)
-        except Exception:
-            pass
     if interactive is True:
         while not local_client.file_exists(CACC_LOCATION):
             _print_and_log(level='warning',

--- a/source/constants/asd.py
+++ b/source/constants/asd.py
@@ -17,8 +17,7 @@
 Constants involved in config management
 """
 
-CACC_SOURCE = '/opt/OpenvStorage/config/arakoon_cacc.ini'
-CACC_LOCATION = '/opt/asd-manager/config/arakoon_cacc.ini'
+CACC_LOCATION = '/opt/OpenvStorage/config/arakoon_cacc.ini'
 ASD_NODE_LOCATION = '/ovs/alba/asdnodes/{0}'
 CONFIG_STORE_LOCATION = '/opt/asd-manager/config/framework.json'
 ASD_NODE_CONFIG_LOCATION = '{0}/config'.format(ASD_NODE_LOCATION)

--- a/source/tools/configuration.py
+++ b/source/tools/configuration.py
@@ -23,6 +23,7 @@ import random
 import string
 from ovs_extensions.dal.base import ObjectNotFoundException
 from ovs_extensions.generic.configuration import Configuration as _Configuration
+from ovs_extensions.constants.config import CONFIG_STORE_LOCATION
 from source.constants.asd import ASD_NODE_CONFIG_MAIN_LOCATION, ASD_NODE_CONFIG_NETWORK_LOCATION, ASD_NODE_CONFIG_IPMI_LOCATION, ASD_NODE_LOCATION
 from source.dal.lists.settinglist import SettingList
 
@@ -93,6 +94,6 @@ class Configuration(_Configuration):
         :return: The store method
         :rtype: str
         """
-        with open(cls.CONFIG_STORE_LOCATION) as config_file:
+        with open(CONFIG_STORE_LOCATION) as config_file:
             contents = json.load(config_file)
             return contents['configuration_store']


### PR DESCRIPTION
Change the

```
opt/<manager>/config/framework.json 
opt/<manager>/config/arakoon_cacc.ini
```
to

```
opt/OpenvStorage/config/framework.json 
opt/OpenvStorage/config/arakoon_cacc.ini
```
so that manager only nodes can properly communicate with eg. proxies.