### PR TITLE
Remove the sshclient after asd-manager setup.

### DIFF
--- a/source/asdmanager.py
+++ b/source/asdmanager.py
@@ -175,10 +175,10 @@ def setup():
         Configuration.uninitialize()
         _print_and_log(level='exception',
                        message='\n' + Interactive.boxed_message(['Starting watcher failed']))
+        del local_client
         sys.exit(1)
 
     del local_client
-
     _print_and_log(message='\n' + Interactive.boxed_message(['ASD Manager setup completed']))
 
 

--- a/source/asdmanager.py
+++ b/source/asdmanager.py
@@ -177,6 +177,8 @@ def setup():
                        message='\n' + Interactive.boxed_message(['Starting watcher failed']))
         sys.exit(1)
 
+    del local_client
+
     _print_and_log(message='\n' + Interactive.boxed_message(['ASD Manager setup completed']))
 
 


### PR DESCRIPTION
This was not done before, which led to stacktraces after the asd-manager setup.
Stacktraces were caused by garbagecollection races vs the paramiko client